### PR TITLE
SkipLibCheck true to skip type checking of node modules

### DIFF
--- a/docs/bottom-navigation/navigation.mdx
+++ b/docs/bottom-navigation/navigation.mdx
@@ -51,7 +51,7 @@ We're mostly going to use the TypeScript template as is, but there are two small
 
 1. remove the `__tests__` folder (we don't be covering testing in this course, but even if we were, placing your test files next to your components is preferrable)
 2. in `.prettierrc.js`, set `bracketSpacing: true,` - this is a personal preference
-3. in `tsconfig.json`, set `"skipLibCheck": false,` - this prevents the `tsc` command from checking `node_modules`
+3. in `tsconfig.json`, set `"skipLibCheck": true,` - this prevents the `tsc` command from checking `node_modules`
 
 ## Update project structure
 


### PR DESCRIPTION
In docs/bottom-navigation/navigation.mdx line 54, boolean value of skipLibCheck should be `true`:

3. in `tsconfig.json`, set `"skipLibCheck": true,` - this prevents the `tsc` command from checking `node_modules`